### PR TITLE
Fix #8 KeyError: '__inner__'

### DIFF
--- a/reloading/reloading.py
+++ b/reloading/reloading.py
@@ -149,8 +149,6 @@ def _reloading_function(fn):
     frame, fpath = inspect.stack()[2][:2]
     caller_locals = frame.f_locals
     caller_globals = frame.f_globals
-    caller_locals_copy = caller_locals.copy()
-    caller_globals_copy = caller_globals.copy()
 
     # if we are redefining the function, we need to load the file path
     # from the function's dictionary as it would be `<string>` otherwise
@@ -159,6 +157,9 @@ def _reloading_function(fn):
         fpath = caller_locals[fn.__name__].__dict__['__fpath__']
 
     def wrapped(*args, **kwargs):
+        caller_locals_copy = caller_locals.copy()
+        caller_globals_copy = caller_globals.copy()
+
         with open(fpath, 'r') as f:
             src = f.read()
 

--- a/reloading/reloading.py
+++ b/reloading/reloading.py
@@ -149,6 +149,8 @@ def _reloading_function(fn):
     frame, fpath = inspect.stack()[2][:2]
     caller_locals = frame.f_locals
     caller_globals = frame.f_globals
+    caller_locals_copy = caller_locals.copy()
+    caller_globals_copy = caller_globals.copy()
 
     # if we are redefining the function, we need to load the file path
     # from the function's dictionary as it would be `<string>` otherwise
@@ -166,7 +168,8 @@ def _reloading_function(fn):
 
         while True:
             try:
-                exec(fn_src, caller_globals, caller_locals)
+                exec(fn_src, caller_globals_copy, caller_locals_copy)
+                caller_locals[fn.__name__].__dict__['__inner__'] = caller_locals_copy[fn.__name__]
                 break
             except Exception:
                 exc = traceback.format_exc()


### PR DESCRIPTION
Suggestion to fix #8.

I'm not exactly sure this pull request follows what you meant to do, but it seems to fix the issue for me.  I found out the call to exec() was overwriting the function reference in `caller_locals`, so `__inner__` was no longer defined.

I'm familiar with Python, but not extremely well versed, so please let me know if this isn't right.

Thanks!