### PR TITLE
Improve performance, streamline code in a LOT of places. Fixed bugs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 dist
 .DS_Store
 examples/FashionMNIST
+.vscode/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ training and, therefore, without losing the training progress.
 
 ## Install
 ```
-pip install reloading
+pip install git+https://github.com/laundmo/reloading.git
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -42,23 +42,23 @@ You can also pass the keyword-only attribute `reload_after` to the `reloading` f
 ```python
 from reloading import reloading
 
-@reloading(reload_after=10)
+@reloading(after=10)
 def some_function():
     pass
 
-for i in reloading(range(10), reload_after=10):
+for i in reloading(range(10), after=10):
     pass
 ```
 This will only trigger a reload every n loops, which is more efficient for fast running loops.
 
-For infinite loops there is also a convenient way of creating them provided, as reloading wont work with `while True:` loops. You can either pass `True` to `reloading` to create a infinite for loop which will have the loop variable `0`, or you can pass a integer which is the step size by which to increment the loop variable each loop.
+For infinite loops there is also a convenient way of creating them provided, as reloading wont work with `while True:` loops. You can either pass `forever=True` to `reloading` to create a infinite for loop which will have the loop variable `0`, or you can pass a integer which is the step size by which to increment the loop variable each loop.
 ```python
 from reloading import reloading
 
-for _ in reloading(True, reload_after=10):
+for _ in reloading(after=10, forever=True):
     pass
 
-for i in reloading(2): # 0, 2, 4, 6, 8 etc.
+for i in reloading(forever=2): # 0, 2, 4, 6, 8 etc.
     pass
 ```
 ## Examples

--- a/README.md
+++ b/README.md
@@ -38,6 +38,29 @@ def some_function():
     pass
 ```
 
+You can also pass the keyword-only attribute `reload_after` to the `reloading` function, like this:
+```python
+from reloading import reloading
+
+@reloading(reload_after=10)
+def some_function():
+    pass
+
+for i in reloading(range(10), reload_after=10):
+    pass
+```
+This will only trigger a reload every n loops, which is more efficient for fast running loops.
+
+For infinite loops there is also a convenient way of creating them provided, as reloading wont work with `while True:` loops. You can either pass `True` to `reloading` to create a infinite for loop which will have the loop variable `0`, or you can pass a integer which is the step size by which to increment the loop variable each loop.
+```python
+from reloading import reloading
+
+for _ in reloading(True, reload_after=10):
+    pass
+
+for i in reloading(2): # 0, 2, 4, 6, 8 etc.
+    pass
+```
 ## Examples
 
 Here are the short snippets of how to use reloading with your favourite library.

--- a/reloading/reloading.py
+++ b/reloading/reloading.py
@@ -6,46 +6,66 @@ import ast
 import traceback
 import types
 from itertools import chain
+from functools import partial, update_wrapper
 
 
-def reloading(fn_or_seq):
-    '''Wraps a loop iterator or decorates a function to reload source code.
+def reloading(*fn_or_seq, **kwargs):
+    """Wraps a loop iterator or decorates a function to reload source code.
 
     A function that when wrapped around the outermost iterator in a for loop,
     causes the loop body to reload from source before every iteration while
     keeping the state.
-    When used as a function decorator, the function is reloaded from source 
+    When used as a function decorator, the function is reloaded from source
     before each execution.
+
+    If the reload_after keyword-only argument is passed, the function/loop
+    body wont be reloaded from source, until that many iterations/calls
+    have passed. This was added to allow for increased performance
+    in fast-running loops.
 
     Args:
         fn_or_seq (function | iterable): A function or loop iterator which should
             be reloaded from source before each execution or iteration,
             respectively
-    '''
-    if isinstance(fn_or_seq, types.FunctionType):
-        return _reloading_function(fn_or_seq)
-    return _reloading_loop(fn_or_seq)
+        reload_after (int, Optional): After how many iterations/calls to reload.
+    """
+    if len(fn_or_seq) > 0:
+        # check if a loop or function was passed, for decorator keyword argument support
+        fn_or_seq = fn_or_seq[0]
+        if isinstance(fn_or_seq, types.FunctionType):
+            return _reloading_function(fn_or_seq, **kwargs)
+        return _reloading_loop(fn_or_seq, **kwargs)
+    else:
+        return update_wrapper(partial(reloading, **kwargs), reloading)
+        # return this function with the keyword arguments partialed in,
+        # so that the return value can be used as a decorator
 
 
-def find_loop(tree):
+def find_loop(tree, lineno=0):
     for child in ast.walk(tree):
+        if getattr(child, "lineno", 0) < lineno:
+            continue
         if not isinstance(child, ast.For):
             continue
         if not isinstance(child.iter, ast.Call):
             continue
-        if child.iter.func.id == 'reloading':
+        if child.iter.func.id == "reloading":
             return child
 
 
 def locate_loop_body(module, loop):
-    ends = set([ node.lineno 
-                    for node in ast.walk(module) 
-                    if hasattr(node, 'lineno') and node.lineno > loop.lineno ])
+    ends = set(
+        [
+            node.lineno
+            for node in ast.walk(module)
+            if hasattr(node, "lineno") and node.lineno > loop.lineno
+        ]
+    )
 
     starts = set()
 
     def visit(node):
-        if hasattr(node, 'lineno') and node.lineno > loop.lineno:
+        if hasattr(node, "lineno") and node.lineno > loop.lineno:
             starts.add(node.lineno)
             if node.lineno in ends:
                 ends.remove(node.lineno)
@@ -55,7 +75,7 @@ def locate_loop_body(module, loop):
     for stmt in loop.body:
         visit(stmt)
 
-    if len(ends) == 0: 
+    if len(ends) == 0:
         return min(starts), -1
 
     return min(starts), min(ends)
@@ -65,77 +85,114 @@ def unique_name(used):
     return max(used, key=len) + "0"
 
 
-def _reloading_loop(seq):
-    frame = inspect.currentframe()
+def tuple_ast_as_name(tup):
+    if isinstance(
+        tup, ast.Name
+    ):  # handle the case that there only is a single loop var
+        return tup.id
+    names = []
+    for child in tup.elts:
+        if isinstance(child, ast.Name):
+            names.append(child.id)
+        elif isinstance(child, ast.Tuple):
+            names.append(
+                f"({tuple_ast_as_name(child)})"
+            )  # if its another tuple, like "a, (b, c)", recurse.
+    return ", ".join(names)
 
-    caller_globals = frame.f_back.f_back.f_globals
-    caller_locals = frame.f_back.f_back.f_locals
+
+def get_loop_code(loop_frame_info):
+    fpath = loop_frame_info[1]
+    with open(fpath, "r") as f:
+        src = f.read() + "\n"
+
+    # find the loop body in the caller module's source
+    tree = ast.parse(src)
+    loop = find_loop(tree, lineno=loop_frame_info.lineno)
+    start, end = locate_loop_body(tree, loop)
+
+    lines = src.split("\n")
+    if end < 0:
+        end = len(lines)
+    body_lines = lines[start - 1 : end - 1]  # -1 as line numbers are 1-indexed
+
+    # find the iteration variables from the loop target ast
+    itervars = tuple_ast_as_name(loop.target)
+
+    # remove indent from lines in loop body, only if a line
+    # starts with this indentation as comments might not
+    indent = re.search("([ \t]*)\S", body_lines[0])
+    body = "\n".join(
+        [
+            line[len(indent.group(1)) :]
+            for line in body_lines
+            if line.startswith(indent.group(1))
+        ]
+    )
+    return compile(body, filename="", mode="exec"), itervars
+
+
+def _reloading_loop(seq, reload_after=1):
+    loop_frame_info = inspect.stack()[2]
+
+    caller_globals = loop_frame_info.frame.f_globals
+    caller_locals = loop_frame_info.frame.f_locals
     unique = unique_name(chain(caller_locals.keys(), caller_globals.keys()))
+    compiled_body, itervars = get_loop_code(loop_frame_info)  # inital call
+    counter = 0
     for j in seq:
-        fpath = inspect.stack()[2][1]
-        with open(fpath, 'r') as f:
-            src = f.read() + '\n'
-
-        # find the iteration variables in the caller module's source
-        match = re.search('\s*for (.+?) in reloading', src)
-        if match is None:
-            break 
-        itervars = match.group(1)
-
-        # find the loop body in the caller module's source
-        tree = ast.parse(src)
-        loop = find_loop(tree)
-        start, end = locate_loop_body(tree, loop)
-        lines  = src.split('\n')
-        if end < 0:
-            end = len(lines)
-        body_lines = lines[start-1:end-1] # -1 as line numbers are 1-indexed
-
-        # remove indent from lines in loop body, only if a line
-        # starts with this indentation as comments might not
-        indent = re.search('([ \t]*)\S', body_lines[0])
-        body = '\n'.join([ line[len(indent.group(1)):] 
-            for line in body_lines 
-            if line.startswith(indent.group(1))])
-
+        if counter % reload_after == 0:
+            compiled_body, itervars = get_loop_code(loop_frame_info)
+        counter += 1
         caller_locals[unique] = j
-        exec(itervars + ' = ' + unique, caller_globals, caller_locals)
-
+        exec(itervars + " = " + unique, caller_globals, caller_locals)
         try:
             # run main loop body
-            exec(body, caller_globals, caller_locals)
+            exec(compiled_body, caller_globals, caller_locals)
         except Exception:
             exc = traceback.format_exc()
             exc = exc.replace('File "<string>"', 'File "{}"'.format(fpath))
-            sys.stderr.write(exc + '\n')
-            print('Edit {} and press return to continue with the next iteration'.format(fpath))
+            sys.stderr.write(exc + "\n")
+            print(
+                "Edit {} and press return to continue with the next iteration".format(
+                    fpath
+                )
+            )
             sys.stdin.readline()
 
     return []
 
 
 def find_function_in_source(fn_name, src):
-    '''Finds line number of start and end of a function with a 
+    """Finds line number of start and end of a function with a
     given name within the given source code.
-    '''
+    """
     tree = ast.parse(src)
 
     # find the parent of the function definition so that we can find out
     # where the function definition ends by using the starting line
     # number of the subsequent child after the function definition
     for parent in ast.walk(tree):
-        fn_end = len(src.split('\n'))
+        fn_end = len(src.split("\n"))
 
         for child in reversed(list(ast.iter_child_nodes(parent))):
-            if not isinstance(child, ast.FunctionDef)\
-               or child.name != fn_name\
-               or not hasattr(child, 'decorator_list')\
-               or len([ 
-                   dec 
-                   for dec in child.decorator_list 
-                   if dec.id == 'reloading' ]) < 1:
-
-                if hasattr(child, 'lineno'):
+            if (
+                not isinstance(child, ast.FunctionDef)
+                or child.name != fn_name
+                or not hasattr(child, "decorator_list")
+                or len(
+                    [
+                        dec
+                        for dec in child.decorator_list
+                        if getattr(dec, "id", "") == "reloading"
+                        or getattr(dec.func, "id", "") == "reloading"
+                    ]
+                )
+                < 1
+            ): 
+                # TODO: Awfull getattr workaround, needs fixing. in fact,
+                # this whole function could need some cleaning up.
+                if hasattr(child, "lineno"):
                     fn_end = child.lineno - 1
                 continue
 
@@ -146,7 +203,17 @@ def find_function_in_source(fn_name, src):
     return -1, -1, 0
 
 
-def _reloading_function(fn):
+def get_function_code(fpath, fn):
+    with open(fpath, "r") as f:
+        src = f.read()
+
+    start, end, indent = find_function_in_source(fn.__name__, src)
+    lines = src.split("\n")
+    fn_src = "\n".join([l[indent:] for l in lines[start - 1 : end]])
+    return fn_src
+
+
+def _reloading_function(fn, reload_after=1):
     frame, fpath = inspect.stack()[2][:2]
     caller_locals = frame.f_locals
     caller_globals = frame.f_globals
@@ -155,41 +222,42 @@ def _reloading_function(fn):
     # from the function's dictionary as it would be `<string>` otherwise
     # which happens when defining functions using `exec`
     if fn.__name__ in caller_locals:
-        fpath = caller_locals[fn.__name__].__dict__['__fpath__']
-
+        fpath = caller_locals[fn.__name__].__dict__["__fpath__"]
+    else:
+        # make sure both of these are initially set,
+        # using the function object to store without having to rely on a global
+        # basically, this is a global for this function
+        _reloading_function.fn_src = get_function_code(fpath, fn)
+        _reloading_function.counter = 0
     def wrapped(*args, **kwargs):
-        with open(fpath, 'r') as f:
-            src = f.read()
-
-        start, end, indent = find_function_in_source(fn.__name__, src)
-        lines = src.split('\n')
-        fn_src = '\n'.join([ l[indent:] for l in lines[start-1:end] ])
-
         while True:
             try:
-                exec(fn_src, caller_globals, caller_locals)
+                if _reloading_function.counter % reload_after == 0:
+                    # access the counter from the function variable, so its not reset each time its redefined
+                    _reloading_function.fn_src = get_function_code(fpath, fn)
+                _reloading_function.counter += 1
+
+                exec(_reloading_function.fn_src, caller_globals, caller_locals)
                 break
             except Exception:
                 exc = traceback.format_exc()
                 exc = exc.replace('File "<string>"', 'File "{}"'.format(fpath))
-                sys.stderr.write(exc + '\n')
-                print('Edit {} and press return to try again'.format(fpath))
+                sys.stderr.write(exc + "\n")
+                print("Edit {} and press return to try again".format(fpath))
                 sys.stdin.readline()
 
-
-        # the newly defined function will also be decorated 
+        # the newly defined function will also be decorated
         # with `reloading` and, hence, we call the inner function without
         # triggering another reload (and another one...)
-        inner = caller_locals[fn.__name__].__dict__['__inner__']
+        inner = caller_locals[fn.__name__].__dict__["__inner__"]
         return inner(*args, **kwargs)
 
-    # save the inner function to be able to call it without 
+    # save the inner function to be able to call it without
     # triggering infinitely recursive reloading
-    wrapped.__dict__['__inner__'] = fn
+    wrapped.__dict__["__inner__"] = fn
     # save the file path for later, as the original file path gets
     # lost by reloading and redefining the function using `exec`
-    wrapped.__dict__['__fpath__'] = fpath
+    wrapped.__dict__["__fpath__"] = fpath
     wrapped.__name__ = fn.__name__
     wrapped.__doc__ = fn.__doc__
-
     return wrapped

--- a/reloading/reloading.py
+++ b/reloading/reloading.py
@@ -131,6 +131,10 @@ def get_loop_code(loop_frame_info):
     loop = find_loop(tree, lineno=loop_frame_info.lineno)
     start, end = locate_loop_body(tree, loop)
 
+    # i hate loading the file twice, but for now im leaving this as a todo
+    # TODO: rwrite function reloading to be ast only 
+    src = load_file(fpath)
+    
     lines = src.split("\n")
     if end < 0:
         end = len(lines)

--- a/reloading/test_reloading.py
+++ b/reloading/test_reloading.py
@@ -5,18 +5,18 @@ import time
 
 from reloading import reloading
 
-SRC_FILE_NAME = 'temporary_testing_file.py'
+SRC_FILE_NAME = "temporary_testing_file.py"
 
-TEST_CHANGING_SOURCE_LOOP_CONTENT = '''
+TEST_CHANGING_SOURCE_LOOP_CONTENT = """
 from reloading import reloading
 from time import sleep
 
 for epoch in reloading(range(10)):
     sleep(0.1)
     print('INITIAL_FILE_CONTENTS')
-'''
+"""
 
-TEST_CHANGING_SOURCE_FN_CONTENT = '''
+TEST_CHANGING_SOURCE_FN_CONTENT = """
 from reloading import reloading
 from time import sleep
 
@@ -27,18 +27,18 @@ def reload_this_fn():
 for epoch in reloading(range(10)):
     sleep(0.1)
     reload_this_fn()
-'''
+"""
 
-TEST_KEEP_LOCAL_VARIABLES_CONTENT = '''
+TEST_KEEP_LOCAL_VARIABLES_CONTENT = """
 from reloading import reloading
 from time import sleep
 
 fpath = "DON'T CHANGE ME"
 for epoch in reloading(range(1)):
     assert fpath == "DON'T CHANGE ME"
-'''
+"""
 
-TEST_PERSIST_AFTER_LOOP = '''
+TEST_PERSIST_AFTER_LOOP = """
 from reloading import reloading
 from time import sleep
 
@@ -47,9 +47,9 @@ for epoch in reloading(range(1)):
     state = 'CHANGED'
 
 assert state == 'CHANGED'
-'''
+"""
 
-TEST_COMMENT_AFTER_LOOP_CONTENT = '''
+TEST_COMMENT_AFTER_LOOP_CONTENT = """
 from reloading import reloading
 from time import sleep
 
@@ -58,9 +58,9 @@ for epoch in reloading(range(10)):
     print('INITIAL_FILE_CONTENTS')
 
 # a comment here should not cause an error
-'''
+"""
 
-TEST_FORMAT_STR_IN_LOOP_CONTENT = '''
+TEST_FORMAT_STR_IN_LOOP_CONTENT = """
 from reloading import reloading
 from time import sleep
 
@@ -68,32 +68,45 @@ for epoch in reloading(range(10)):
     sleep(0.1)
     file_contents = 'FILE_CONTENTS'
     print(f'INITIAL_{file_contents}')
-'''
+"""
+
+TEST_FUNCTION_RELOAD_AFTER = """
+from reloading import reloading
+from time import sleep
+
+@reloading(reload_after=2)
+def some_func(a, b):
+    sleep(0.1)
+    print(a+b)
+
+for _ in range(10):
+    some_func(2,1)
+"""
 
 
 def run_and_update_source(init_src, updated_src=None, update_after=0.5):
-    '''Runs init_src in a subprocess and updates source to updated_src after
+    """Runs init_src in a subprocess and updates source to updated_src after
     update_after seconds. Returns the standard output of the subprocess and
     whether the subprocess produced an uncaught exception.
-    '''
-    with open(SRC_FILE_NAME, 'w') as f:
+    """
+    with open(SRC_FILE_NAME, "w") as f:
         f.write(init_src)
 
-    cmd = ['python3', SRC_FILE_NAME]
+    cmd = ["py", "-3.9", SRC_FILE_NAME]
     with sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE) as proc:
         if updated_src != None:
             time.sleep(update_after)
-            with open(SRC_FILE_NAME, 'w') as f:
+            with open(SRC_FILE_NAME, "w") as f:
                 f.write(updated_src)
 
         try:
             stdout, _ = proc.communicate(timeout=2)
-            stdout = stdout.decode('utf-8')
+            stdout = stdout.decode("utf-8")
             has_error = False
         except:
-            stdout = ''
+            stdout = ""
             has_error = True
-            proc.terminate() 
+            proc.terminate()
 
     if os.path.isfile(SRC_FILE_NAME):
         os.remove(SRC_FILE_NAME)
@@ -102,7 +115,6 @@ def run_and_update_source(init_src, updated_src=None, update_after=0.5):
 
 
 class TestReloading(unittest.TestCase):
-
     def test_simple_looping(self):
         iters = 0
         for _ in reloading(range(10)):
@@ -110,27 +122,39 @@ class TestReloading(unittest.TestCase):
 
     def test_changing_source_loop(self):
         stdout, _ = run_and_update_source(
-          init_src=TEST_CHANGING_SOURCE_LOOP_CONTENT,
-          updated_src=TEST_CHANGING_SOURCE_LOOP_CONTENT.replace('INITIAL', 'CHANGED').rstrip('\n'))
+            init_src=TEST_CHANGING_SOURCE_LOOP_CONTENT,
+            updated_src=TEST_CHANGING_SOURCE_LOOP_CONTENT.replace(
+                "INITIAL", "CHANGED"
+            ).rstrip("\n"),
+        )
 
-        self.assertTrue('INITIAL_FILE_CONTENTS' in stdout and
-                        'CHANGED_FILE_CONTENTS' in stdout)
+        self.assertTrue(
+            "INITIAL_FILE_CONTENTS" in stdout and "CHANGED_FILE_CONTENTS" in stdout
+        )
 
     def test_comment_after_loop(self):
         stdout, _ = run_and_update_source(
-          init_src=TEST_COMMENT_AFTER_LOOP_CONTENT,
-          updated_src=TEST_COMMENT_AFTER_LOOP_CONTENT.replace('INITIAL', 'CHANGED').rstrip('\n'))
+            init_src=TEST_COMMENT_AFTER_LOOP_CONTENT,
+            updated_src=TEST_COMMENT_AFTER_LOOP_CONTENT.replace(
+                "INITIAL", "CHANGED"
+            ).rstrip("\n"),
+        )
 
-        self.assertTrue('INITIAL_FILE_CONTENTS' in stdout and
-                        'CHANGED_FILE_CONTENTS' in stdout)
+        self.assertTrue(
+            "INITIAL_FILE_CONTENTS" in stdout and "CHANGED_FILE_CONTENTS" in stdout
+        )
 
     def test_format_str_in_loop(self):
         stdout, _ = run_and_update_source(
-          init_src=TEST_FORMAT_STR_IN_LOOP_CONTENT,
-          updated_src=TEST_FORMAT_STR_IN_LOOP_CONTENT.replace('INITIAL', 'CHANGED').rstrip('\n'))
+            init_src=TEST_FORMAT_STR_IN_LOOP_CONTENT,
+            updated_src=TEST_FORMAT_STR_IN_LOOP_CONTENT.replace(
+                "INITIAL", "CHANGED"
+            ).rstrip("\n"),
+        )
 
-        self.assertTrue('INITIAL_FILE_CONTENTS' in stdout and
-                        'CHANGED_FILE_CONTENTS' in stdout)
+        self.assertTrue(
+            "INITIAL_FILE_CONTENTS" in stdout and "CHANGED_FILE_CONTENTS" in stdout
+        )
 
     def test_keep_local_variables(self):
         _, has_error = run_and_update_source(init_src=TEST_KEEP_LOCAL_VARIABLES_CONTENT)
@@ -143,18 +167,31 @@ class TestReloading(unittest.TestCase):
     def test_simple_function(self):
         @reloading
         def some_func():
-            return 'result'
-        
-        self.assertTrue(some_func() == 'result')
+            return "result"
+
+        self.assertTrue(some_func() == "result")
+
+    def test_reloading_function(self):
+        stdout, _ = run_and_update_source(
+            init_src=TEST_FUNCTION_RELOAD_AFTER,
+            updated_src=TEST_FUNCTION_RELOAD_AFTER.replace("a+b", "a-b"),
+        )
+        self.assertTrue(
+            "3" in stdout and "1" in stdout
+        )
 
     def test_changing_source_function(self):
         stdout, _ = run_and_update_source(
-          init_src=TEST_CHANGING_SOURCE_FN_CONTENT,
-          updated_src=TEST_CHANGING_SOURCE_FN_CONTENT.replace('INITIAL', 'CHANGED').rstrip('\n'))
+            init_src=TEST_CHANGING_SOURCE_FN_CONTENT,
+            updated_src=TEST_CHANGING_SOURCE_FN_CONTENT.replace(
+                "INITIAL", "CHANGED"
+            ).rstrip("\n"),
+        )
 
-        self.assertTrue('INITIAL_FILE_CONTENTS' in stdout and
-                        'CHANGED_FILE_CONTENTS' in stdout)
+        self.assertTrue(
+            "INITIAL_FILE_CONTENTS" in stdout and "CHANGED_FILE_CONTENTS" in stdout
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/reloading/test_reloading.py
+++ b/reloading/test_reloading.py
@@ -12,7 +12,7 @@ from reloading import reloading
 from time import sleep
 
 for epoch in reloading(range(10)):
-    sleep(0.1)
+    sleep(0.2)
     print('INITIAL_FILE_CONTENTS')
 """
 
@@ -25,7 +25,7 @@ def reload_this_fn():
     print('INITIAL_FILE_CONTENTS')
 
 for epoch in reloading(range(10)):
-    sleep(0.1)
+    sleep(0.2)
     reload_this_fn()
 """
 
@@ -54,7 +54,7 @@ from reloading import reloading
 from time import sleep
 
 for epoch in reloading(range(10)):
-    sleep(0.1)
+    sleep(0.2)
     print('INITIAL_FILE_CONTENTS')
 
 # a comment here should not cause an error
@@ -65,18 +65,18 @@ from reloading import reloading
 from time import sleep
 
 for epoch in reloading(range(10)):
-    sleep(0.1)
+    sleep(0.2)
     file_contents = 'FILE_CONTENTS'
     print(f'INITIAL_{file_contents}')
 """
 
-TEST_FUNCTION_RELOAD_AFTER = """
+TEST_FUNCTION_AFTER = """
 from reloading import reloading
 from time import sleep
 
-@reloading(reload_after=2)
+@reloading(every=2)
 def some_func(a, b):
-    sleep(0.1)
+    sleep(0.2)
     print(a+b)
 
 for _ in range(10):
@@ -94,7 +94,7 @@ def run_and_update_source(init_src, updated_src=None, update_after=0.5):
 
     cmd = ["py", "-3.9", SRC_FILE_NAME]
     with sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE) as proc:
-        if updated_src != None:
+        if updated_src is not None:
             time.sleep(update_after)
             with open(SRC_FILE_NAME, "w") as f:
                 f.write(updated_src)
@@ -173,12 +173,10 @@ class TestReloading(unittest.TestCase):
 
     def test_reloading_function(self):
         stdout, _ = run_and_update_source(
-            init_src=TEST_FUNCTION_RELOAD_AFTER,
-            updated_src=TEST_FUNCTION_RELOAD_AFTER.replace("a+b", "a-b"),
+            init_src=TEST_FUNCTION_AFTER,
+            updated_src=TEST_FUNCTION_AFTER.replace("a+b", "a-b"),
         )
-        self.assertTrue(
-            "3" in stdout and "1" in stdout
-        )
+        self.assertTrue("3" in stdout and "1" in stdout)
 
     def test_changing_source_function(self):
         stdout, _ = run_and_update_source(


### PR DESCRIPTION
Bugs fixed:
- can only have a single reloading loop - now works with multiple
- loop vars if reloading loop isn't first were wrong. - dumb regex looked at the first loop it could find, now getting vars using ast.

Performance improvements:
- now allows for the keyword only argument reload_after, which will only reload the code every n iterations
- reduced total number of inspect calls
- compile() the code first, before running it

Reloading loop performance comparison: 
![image](https://user-images.githubusercontent.com/24855949/109418254-b65e0580-79c7-11eb-87e5-272b8fbff841.png)
`r` is the reload_after
`old` refers to whether this is the old version of the library.

The benchmark code is avaliable on [laundmo:benchmark](https://github.com/laundmo/reloading/tree/benchmark)

This is heavily related to #10 