### PR TITLE
Do not re-execute decorators before `reloading`

### DIFF
--- a/reloading/reloading.py
+++ b/reloading/reloading.py
@@ -178,16 +178,21 @@ def _reloading_loop(seq, every=1):
     return []
 
 
-def get_decorator_name(dec_node):
+def get_decorator_name_or_none(dec_node):
     if hasattr(dec_node, "id"):
         return dec_node.id
-    return dec_node.func.id
+    elif hasattr(dec_node.func, "id"):
+        return dec_node.func.id
+    elif hasattr(dec_node.func.value, "id"):
+        return dec_node.func.value.id
+    else:
+        return None
 
 
 def strip_reloading_decorator(func):
     """Remove the reloading decorator in-place"""
     func.decorator_list = [
-        dec for dec in func.decorator_list if get_decorator_name(dec) != "reloading"
+        dec for dec in func.decorator_list if get_decorator_name_or_none(dec) != "reloading"
     ]
 
 
@@ -199,7 +204,7 @@ def isolate_function_def(funcname, tree):
             isinstance(node, ast.FunctionDef)
             and node.name == funcname
             and "reloading" in [
-                get_decorator_name(dec)
+                get_decorator_name_or_none(dec)
                 for dec in node.decorator_list
             ]
         ):

--- a/reloading/reloading.py
+++ b/reloading/reloading.py
@@ -190,10 +190,10 @@ def get_decorator_name_or_none(dec_node):
 
 
 def strip_reloading_decorator(func):
-    """Remove the reloading decorator in-place"""
-    func.decorator_list = [
-        dec for dec in func.decorator_list if get_decorator_name_or_none(dec) != "reloading"
-    ]
+    """Remove the 'reloading' decorator and all decorators before it"""
+    decorator_names = [get_decorator_name(dec) for dec in func.decorator_list]
+    reloading_idx = decorator_names.index("reloading")
+    func.decorator_list = func.decorator_list[reloading_idx + 1:]
 
 
 def isolate_function_def(funcname, tree):

--- a/reloading/reloading.py
+++ b/reloading/reloading.py
@@ -18,13 +18,13 @@ class no_iter_partial(partial):
 
 
 def reloading(fn_or_seq=None, every=1, forever=None):
-    """Wraps a loop iterator or decorates a function to reload the source code 
+    """Wraps a loop iterator or decorates a function to reload the source code
     before every loop iteration or function invocation.
 
-    When wrapped around the outermost iterator in a `for` loop, e.g. 
-    `for i in reloading(range(10))`, causes the loop body to reload from source 
+    When wrapped around the outermost iterator in a `for` loop, e.g.
+    `for i in reloading(range(10))`, causes the loop body to reload from source
     before every iteration while keeping the state.
-    When used as a function decorator, the decorated function is reloaded from 
+    When used as a function decorator, the decorated function is reloaded from
     source before each execution.
 
     Pass the integer keyword argument `every` to reload the source code
@@ -61,7 +61,7 @@ def format_itervars(ast_node):
     """Formats an `ast_node` of loop iteration variables as string, e.g. 'a, b'"""
 
     # handle the case that there only is a single loop var
-    if isinstance(ast_node, ast.Name):  
+    if isinstance(ast_node, ast.Name):
         return ast_node.id
 
     names = []
@@ -70,7 +70,7 @@ def format_itervars(ast_node):
             names.append(child.id)
         elif isinstance(child, ast.Tuple) or isinstance(child, ast.List):
             # if its another tuple, like "a, (b, c)", recurse
-            names.append("({})".format(format_itervars(child)))  
+            names.append("({})".format(format_itervars(child)))
 
     return ", ".join(names)
 
@@ -78,7 +78,7 @@ def format_itervars(ast_node):
 def load_file(path):
     src = ""
     # while loop here since while saving, the file may sometimes be empty.
-    while (src == ""):  
+    while (src == ""):
         with open(path, "r") as f:
             src = f.read()
     return src + "\n"
@@ -101,11 +101,11 @@ def isolate_loop_body_and_get_itervars(tree, lineno, loop_id):
     candidate_nodes = []
     for node in ast.walk(tree):
         if (
-            isinstance(node, ast.For) 
+            isinstance(node, ast.For)
             and isinstance(node.iter, ast.Call)
-            and node.iter.func.id == "reloading" 
+            and node.iter.func.id == "reloading"
             and (
-                    (loop_id is not None and loop_id == get_loop_id(node)) 
+                    (loop_id is not None and loop_id == get_loop_id(node))
                     or getattr(node, "lineno", None) == lineno
                 )
             ):
@@ -120,7 +120,7 @@ def isolate_loop_body_and_get_itervars(tree, lineno, loop_id):
         raise LookupError(
             "Could not locate reloading loop. Please make sure the code in the line that uses `reloading` doesn't change between reloads."
         )
-    
+
     loop_node = candidate_nodes[0]
     tree.body = loop_node.body
     return loop_node.target, get_loop_id(loop_node)
@@ -158,7 +158,7 @@ def _reloading_loop(seq, every=1):
     caller_globals = loop_frame_info[0].f_globals
     caller_locals = loop_frame_info[0].f_locals
 
-    # create a unique name in the caller namespace that we can safely write 
+    # create a unique name in the caller namespace that we can safely write
     # the values of the iteration variables into
     unique = unique_name(chain(caller_locals.keys(), caller_globals.keys()))
     loop_id = None
@@ -204,7 +204,7 @@ def isolate_function_def(funcname, tree):
             ]
         ):
             strip_reloading_decorator(node)
-            tree.body = [ node ]  
+            tree.body = [ node ]
             return True
     return False
 


### PR DESCRIPTION
Currently, in master, all decorators (except the `@reloading` one)
on a function are re-executed, including the ones before `@reloading`.
It seems to be more intuitive, however, to only re-execute decorators
after `@reloading`. It also gives the user more control over what
is re-executed and what is not, since they can re-order their decorators.

With this PR, `@my_dec` in the following code will not be re-executed:

```python
@my_dec
@reloading
def func():
    pass
```

However, it will be in the following code:

```python
@reloading
@my_dec
def func():
    pass
```

Fixes: #19